### PR TITLE
Implement bulk unsubscribe functionality

### DIFF
--- a/unsubscribes.go
+++ b/unsubscribes.go
@@ -17,6 +17,12 @@ type unsubscribesResponse struct {
 	Items  []Unsubscribe `json:"items"`
 }
 
+type NewUnsubscribe struct {
+	CreatedAt RFC2822Time `json:"created_at,omitempty"`
+	Tags      []string    `json:"tags,omitempty"`
+	Address   string      `json:"address"`
+}
+
 // Fetches the list of unsubscribes
 func (mg *MailgunImpl) ListUnsubscribes(opts *ListOptions) *UnsubscribesIterator {
 	r := newHTTPRequest(generateApiUrl(mg, unsubscribesEndpoint))
@@ -153,6 +159,20 @@ func (mg *MailgunImpl) CreateUnsubscribe(ctx context.Context, address, tag strin
 	p.addValue("address", address)
 	p.addValue("tag", tag)
 	_, err := makePostRequest(ctx, r, p)
+	return err
+}
+
+// CreateUnsubscribes adds a list of e-mail addresses to the domain's unsubscription table.
+func (mg *MailgunImpl) CreateUnsubscribes(ctx context.Context, unsubscribes []NewUnsubscribe) error {
+	r := newHTTPRequest(generateApiUrl(mg, unsubscribesEndpoint))
+	r.setClient(mg.Client())
+	r.setBasicAuth(basicAuthUser, mg.APIKey())
+	p := newJSONEncodedPayload()
+	err := p.addJSON(unsubscribes)
+	if err != nil {
+		return err
+	}
+	_, err = makePostRequest(ctx, r, p)
 	return err
 }
 

--- a/unsubscribes_test.go
+++ b/unsubscribes_test.go
@@ -22,6 +22,27 @@ func TestCreateUnsubscriber(t *testing.T) {
 	ensure.Nil(t, mg.CreateUnsubscribe(ctx, email, "*"))
 }
 
+func TestCreateUnsubscribes(t *testing.T) {
+	if reason := SkipNetworkTest(); reason != "" {
+		t.Skip(reason)
+	}
+
+	email := randomEmail("unsubcribe", os.Getenv("MG_DOMAIN"))
+	mg, err := NewMailgunFromEnv()
+	ensure.Nil(t, err)
+	ctx := context.Background()
+
+	unsubscribes := []NewUnsubscribe{}
+	unsubscribes = append(unsubscribes,
+		NewUnsubscribe{
+			Address: email,
+			Tags:    []string{"*"},
+		})
+
+	// Create unsubscription record
+	ensure.Nil(t, mg.CreateUnsubscribes(ctx, unsubscribes))
+}
+
 func TestListUnsubscribes(t *testing.T) {
 	if reason := SkipNetworkTest(); reason != "" {
 		t.Skip(reason)


### PR DESCRIPTION
Implements the [bulk unsubscribe](https://documentation.mailgun.com/en/latest/api-suppressions.html#add-multiple-unsubscribes) portion of the Mailgun API to support unsubscribing up to 1000 email addresses in a single call. This requires a JSON-encoded request body rather than a URL-encoded one due to its size so I had to create a new jsonEncodedPayload struct to send arbitrary JSON strings. 

In testing with hail, I was able to unsubscribe two of my email addresses with a random tag in a single API call to our staging.bolt.com domain.

![image](https://user-images.githubusercontent.com/55464043/93916612-a88cb180-fcbe-11ea-908b-a15dddf87076.png)
